### PR TITLE
"base64binary" to "base64Binary"

### DIFF
--- a/BaSyx.Models/Core/Common/DataObjectType.cs
+++ b/BaSyx.Models/Core/Common/DataObjectType.cs
@@ -92,7 +92,7 @@ namespace BaSyx.Models.Core.Common
         public static readonly DataObjectType DateTimeStamp = new DataObjectType("dateTimeStamp");
 
         public static readonly DataObjectType AnyURI = new DataObjectType("anyURI");
-        public static readonly DataObjectType Base64Binary = new DataObjectType("base64binary");
+        public static readonly DataObjectType Base64Binary = new DataObjectType("base64Binary");
         public static readonly DataObjectType HexBinary = new DataObjectType("hexBinary");
 
         private static readonly Dictionary<string, DataObjectType> _dataObjectTypes;


### PR DESCRIPTION
Hello,
I believe there is a typo in line 95 of the BaSyx.Models/Core/Common/DataObjectType.cs file.
Shouldn't it be "base64Binary" since [Details of the Asset Administration Shell](https://www.plattform-i40.de/IP/Redaktion/DE/Downloads/Publikation/Details_of_the_Asset_Administration_Shell_Part_2_V1.pdf?__blob=publicationFile&v=8) page 102 states "base64Binary". Also, the [AASX Package Explorer](https://github.com/admin-shell-io/aasx-package-explorer) writes the value type as "base64Binary".